### PR TITLE
[BUGFIX] Exclude `.github` directory from dist archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,10 @@
 * text=auto
 /.ddev export-ignore
+/.github export-ignore
 /Tests export-ignore
 /.editorconfig export-ignore
-/.gitignore export-ignore
 /.gitattributes export-ignore
+/.gitignore export-ignore
 /composer.lock export-ignore
 /package.json export-ignore
 /package-lock.json export-ignore


### PR DESCRIPTION
This pull request updates the `.gitattributes` file to adjust the export-ignore rules for specific files and directories.

Export-ignore adjustments:

* Added `.github` to the export-ignore list to exclude it from export operations.
* Reordered `.gitignore` within the export-ignore list for consistency, but its inclusion remains unchanged.