### PR TITLE
[TASK] Validate PHP files in CGL workflow

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -23,3 +23,6 @@ jobs:
       # Validation
       - name: Validate composer.json
         run: composer validate --strict
+      - name: Validate PHP files
+        run: |
+          find . -type d \( -name .ddev -o -name config -o -name public -o -name var -o -name vendor \) -prune -false -o -type f -name '*.php' -print0 | xargs -0 -I{} php -l {}


### PR DESCRIPTION
This pull request adds a new validation step to the GitHub Actions workflow for PHP files. The change ensures that all PHP files, excluding specific directories, are syntax-checked during the workflow.

* [`.github/workflows/cgl.yaml`](diffhunk://#diff-e67ee0bda8360eba38abf2112c768f6e3ae49653d41da3501f64632426e982eaR26-R28): Added a new step named "Validate PHP files" to perform syntax checks on all PHP files, while excluding directories like `.ddev`, `config`, `public`, `var`, and `vendor`.