### PR TITLE
[FEATURE] Add validator to enforce password policy on member registration

### DIFF
--- a/Classes/Controller/MembershipController.php
+++ b/Classes/Controller/MembershipController.php
@@ -40,6 +40,7 @@ use TYPO3Incubator\Memsy\Domain\Model\MembershipStatus;
 use TYPO3Incubator\Memsy\Domain\Repository\MemberRepository;
 use TYPO3Incubator\Memsy\Domain\Repository\MembershipRepository;
 use TYPO3Incubator\Memsy\Exception\Exception;
+use TYPO3Incubator\Memsy\PasswordPolicy\MemberPasswordPolicyResolver;
 use TYPO3Incubator\Memsy\Service\MembershipService;
 
 /**
@@ -51,6 +52,7 @@ use TYPO3Incubator\Memsy\Service\MembershipService;
 final class MembershipController extends ActionController
 {
     public function __construct(
+        private readonly MemberPasswordPolicyResolver $passwordPolicyResolver,
         private readonly MemberRepository $memberRepository,
         private readonly MembershipRepository $membershipRepository,
         private readonly MembershipService $membershipService,
@@ -86,6 +88,7 @@ final class MembershipController extends ActionController
             'memberships' => $memberships,
             'sitesets' => $this->request->getAttribute('site')->getSettings()->getAll(),
             'data' => $this->getContentObjectData(),
+            'passwordRequirements' => $this->passwordPolicyResolver->getValidator()?->getRequirements(),
         ]);
 
         return $this->htmlResponse();

--- a/Classes/Domain/Model/Member.php
+++ b/Classes/Domain/Model/Member.php
@@ -27,6 +27,7 @@ use TYPO3\CMS\Extbase\Annotation\Validate;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 use TYPO3Incubator\Memsy\Domain\Validator\IbanValidator;
+use TYPO3Incubator\Memsy\Domain\Validator\PasswordPolicyValidator;
 use TYPO3Incubator\Memsy\Domain\Validator\PasswordRepeatValidator;
 
 /**
@@ -106,6 +107,8 @@ class Member extends AbstractEntity
     protected ObjectStorage $payments;
 
     protected string $username = '';
+
+    #[Validate(['validator' => PasswordPolicyValidator::class])]
     protected string $password = '';
 
     #[Validate([

--- a/Classes/Domain/Validator/PasswordPolicyValidator.php
+++ b/Classes/Domain/Validator/PasswordPolicyValidator.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "memsy".
+ *
+ * Copyright (C) 2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace TYPO3Incubator\Memsy\Domain\Validator;
+
+use TYPO3\CMS\Extbase\Validation\Validator\AbstractValidator;
+use TYPO3Incubator\Memsy\PasswordPolicy\MemberPasswordPolicyResolver;
+
+/**
+ * PasswordPolicyValidator
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+final class PasswordPolicyValidator extends AbstractValidator
+{
+    protected $supportedOptions = [
+        'tableName' => ['fe_users', 'The table name contains the password field', 'string'],
+        'fieldName' => ['password', 'The field name that represents a password', 'string'],
+    ];
+
+    public function __construct(
+        private readonly MemberPasswordPolicyResolver $passwordPolicyResolver,
+    ) {}
+
+    protected function isValid(mixed $value): void
+    {
+        // Early return if invalid password is given
+        if (!is_string($value)) {
+            return;
+        }
+
+        $validator = $this->passwordPolicyResolver->getValidator();
+
+        if ($validator !== null && !$validator->isValidPassword($value)) {
+            $messageComponents = [
+                'The given password is not strong enough:',
+                ...array_map(
+                    static fn (string $message) => '- ' . $message,
+                    $validator->getValidationErrors(),
+                ),
+            ];
+
+            $this->addError(
+                implode(PHP_EOL, $messageComponents),
+                1747594256,
+            );
+        }
+    }
+}

--- a/Classes/PasswordPolicy/MemberPasswordPolicyResolver.php
+++ b/Classes/PasswordPolicy/MemberPasswordPolicyResolver.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "memsy".
+ *
+ * Copyright (C) 2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace TYPO3Incubator\Memsy\PasswordPolicy;
+
+use TYPO3\CMS\Core\PasswordPolicy\PasswordPolicyAction;
+use TYPO3\CMS\Core\PasswordPolicy\PasswordPolicyValidator;
+use TYPO3\CMS\Core\Schema\Exception\UndefinedFieldException;
+use TYPO3\CMS\Core\Schema\Exception\UndefinedSchemaException;
+use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
+
+/**
+ * MemberPasswordPolicyResolver
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+final readonly class MemberPasswordPolicyResolver
+{
+    public function __construct(
+        private TcaSchemaFactory $tcaSchemaFactory,
+    ) {}
+
+    public function getValidator(): ?PasswordPolicyValidator
+    {
+        try {
+            $schema = $this->tcaSchemaFactory->get('fe_users');
+            $field = $schema->getField('password');
+        } catch (UndefinedSchemaException|UndefinedFieldException) {
+            return null;
+        }
+
+        $passwordPolicy = $field->getConfiguration()['passwordPolicy'] ?? null;
+
+        // Early return if no (valid) password policy is configured
+        if (!is_string($passwordPolicy)) {
+            return null;
+        }
+
+        return new PasswordPolicyValidator(PasswordPolicyAction::NEW_USER_PASSWORD, $passwordPolicy);
+    }
+}

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -241,6 +241,10 @@
             <trans-unit id="error.unknown">
                 <source>An unknown error occurred. Please contact your person in charge.</source>
             </trans-unit>
+
+            <trans-unit id="passwordRequirements">
+                <source>The password must match the following requirements</source>
+            </trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Partials/Alert.html
+++ b/Resources/Private/Partials/Alert.html
@@ -1,8 +1,8 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-<div class="alert alert-{severity}" role="alert">
-    {content}
+<div class="alert alert-{severity} {additionalClasses}" role="alert">
+    {content -> f:format.raw() -> f:spaceless() -> f:format.nl2br()}
 </div>
 
 </html>

--- a/Resources/Private/Templates/Membership/Create.html
+++ b/Resources/Private/Templates/Membership/Create.html
@@ -81,8 +81,21 @@
                 </f:for>
             </f:form.select>
         </div>
+
         <f:render partial="Input"
             arguments="{ type: 'password', id: 'password', name: 'password', required: true}" />
+
+        <f:if condition="{passwordRequirements}">
+            <f:render partial="Alert" arguments="{severity: 'light', additionalClasses: 'px-3 py-2 small'}" contentAs="content">
+                <f:translate key="passwordRequirements" />:
+                <ul class="list-chevron mb-0">
+                    <f:for each="{passwordRequirements}" as="requirement">
+                        <li>{requirement}</li>
+                    </f:for>
+                </ul>
+            </f:render>
+        </f:if>
+
         <f:render partial="Input"
             arguments="{ type: 'password', id: 'password-repeat', name: 'passwordRepeat', required: true}" />
     </fieldset>


### PR DESCRIPTION
This PR introduces a validator to enforce a given password policy during member registration. If a policy is configured for `fe_users.password` (which by default is `default`), the requirements will be rendered like follows:

<img width="643" alt="image" src="https://github.com/user-attachments/assets/4e2ad137-c6bf-42aa-ab79-2e6af2aa05ae" />

After submit, the submitted password is validated on server-side using the new validator. If any requirement is not met, an error is shown:

<img width="630" alt="image" src="https://github.com/user-attachments/assets/6cd45d79-b9f3-4143-88d5-dc8ea3b792a3" />


Resolves: #9