### PR TITLE
[FEATURE] Add validator for date of birth

### DIFF
--- a/Classes/Domain/Model/Member.php
+++ b/Classes/Domain/Model/Member.php
@@ -85,13 +85,8 @@ class Member extends AbstractEntity
 
     #[Validate(['validator' => 'NotEmpty'])]
     #[Validate(['validator' => 'DateTime'])]
-    #[Validate([
-        'validator' => DateIntervalValidator::class,
-        'options' => [
-            'interval' => 'P18Y', // 18 years
-            'message' => 'LLL:EXT:memsy/Resources/Private/Language/locallang.xlf:error.dateOfBirth.tooYoung',
-        ],
-    ])]
+    // Interval and message are set by MembershipController::initializeSaveAction
+    #[Validate(['validator' => DateIntervalValidator::class])]
     protected ?\DateTime $dateOfBirth = null;
 
     protected Gender $gender = Gender::NoSelection;

--- a/Classes/Domain/Model/Member.php
+++ b/Classes/Domain/Model/Member.php
@@ -26,6 +26,7 @@ namespace TYPO3Incubator\Memsy\Domain\Model;
 use TYPO3\CMS\Extbase\Annotation\Validate;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
+use TYPO3Incubator\Memsy\Domain\Validator\DateIntervalValidator;
 use TYPO3Incubator\Memsy\Domain\Validator\IbanValidator;
 use TYPO3Incubator\Memsy\Domain\Validator\PasswordRepeatValidator;
 
@@ -83,6 +84,13 @@ class Member extends AbstractEntity
 
     #[Validate(['validator' => 'NotEmpty'])]
     #[Validate(['validator' => 'DateTime'])]
+    #[Validate([
+        'validator' => DateIntervalValidator::class,
+        'options' => [
+            'interval' => 'P18Y', // 18 years
+            'message' => 'LLL:EXT:memsy/Resources/Private/Language/locallang.xlf:error.dateOfBirth.tooYoung',
+        ],
+    ])]
     protected ?\DateTime $dateOfBirth = null;
 
     protected Gender $gender = Gender::NoSelection;

--- a/Classes/Domain/Validator/DateIntervalValidator.php
+++ b/Classes/Domain/Validator/DateIntervalValidator.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "memsy".
+ *
+ * Copyright (C) 2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace TYPO3Incubator\Memsy\Domain\Validator;
+
+use TYPO3\CMS\Extbase\Validation\Validator\AbstractValidator;
+
+/**
+ * DateIntervalValidator
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+final class DateIntervalValidator extends AbstractValidator
+{
+    protected $supportedOptions = [
+        'interval' => [null, 'The interval to validate, must be readable by the DateInterval class', 'string'],
+        'message' => [null, 'Translation key or message for invalid value', 'string'],
+    ];
+
+    protected function isValid(mixed $value): void
+    {
+        // Early return if value is not a date object
+        if (!($value instanceof \DateTime)) {
+            return;
+        }
+
+        try {
+            $interval = new \DateInterval($this->options['interval']);
+        } catch (\DateMalformedIntervalStringException) {
+            $this->addError(
+                'The configured date interval is not valid.',
+                1747596596,
+            );
+
+            return;
+        }
+
+        $now = new \DateTimeImmutable();
+        $target = $value->add($interval);
+
+        if ($target->getTimestamp() >= $now->getTimestamp()) {
+            $this->addError(
+                $this->translateErrorMessage($this->options['message']),
+                1747596742,
+            );
+        }
+    }
+}

--- a/Configuration/Sets/MemberManagement/config.yaml
+++ b/Configuration/Sets/MemberManagement/config.yaml
@@ -21,7 +21,5 @@ settings:
         sepaCreditorId: ''
         paymentReason: ''
         paymentDueMonth: ''
-        paymentReminderPeriod: ''
-        paymentGracePeriod: ''
     membership:
       minimumAgeInYears: ''

--- a/Configuration/Sets/MemberManagement/config.yaml
+++ b/Configuration/Sets/MemberManagement/config.yaml
@@ -21,3 +21,7 @@ settings:
         sepaCreditorId: ''
         paymentReason: ''
         paymentDueMonth: ''
+        paymentReminderPeriod: ''
+        paymentGracePeriod: ''
+    membership:
+      minimumAgeInYears: ''

--- a/Configuration/Sets/MemberManagement/settings.definitions.yaml
+++ b/Configuration/Sets/MemberManagement/settings.definitions.yaml
@@ -13,6 +13,9 @@ categories:
   Memsy.organization.paymentInformation:
     label: 'Payment information'
     parent: Memsy.organization
+  Memsy.membership:
+    label: 'Membership'
+    parent: Memsy
 
 settings:
   memsy.storage.membershipsFolderPid:
@@ -119,3 +122,8 @@ settings:
     category: Memsy.organization.paymentInformation
     type: string
     default: 'P3M' # 3 months
+  memsy.membership.minimumAgeInYears:
+    label: 'Minimum age of new members (in years)'
+    category: Memsy.membership
+    type: int
+    default: 18

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -241,6 +241,9 @@
             <trans-unit id="error.unknown">
                 <source>An unknown error occurred. Please contact your person in charge.</source>
             </trans-unit>
+            <trans-unit id="error.dateOfBirth.tooYoung">
+                <source>You must be 18 years old to register as a new member.</source>
+            </trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -242,7 +242,7 @@
                 <source>An unknown error occurred. Please contact your person in charge.</source>
             </trans-unit>
             <trans-unit id="error.dateOfBirth.tooYoung">
-                <source>You must be 18 years old to register as a new member.</source>
+                <source>You must be %d years old to register as a new member.</source>
             </trans-unit>
 
             <trans-unit id="passwordRequirements">

--- a/composer.json
+++ b/composer.json
@@ -12,19 +12,19 @@
         "symfony/console": "^7.0",
         "symfony/mailer": "^7.0",
         "symfony/mime": "^7.0",
-        "typo3/cms-backend": "^13.4",
-        "typo3/cms-core": "^13.4",
-        "typo3/cms-extbase": "^13.4",
-        "typo3/cms-frontend": "^13.4",
+        "typo3/cms-backend": "~13.4.13",
+        "typo3/cms-core": "~13.4.13",
+        "typo3/cms-extbase": "~13.4.13",
+        "typo3/cms-frontend": "~13.4.13",
         "typo3fluid/fluid": "^4.1"
     },
     "require-dev": {
-        "typo3/cms-felogin": "^13.4",
-        "typo3/cms-scheduler": "^13.4"
+        "typo3/cms-felogin": "~13.4.13",
+        "typo3/cms-scheduler": "~13.4.13"
     },
     "suggest": {
-        "typo3/cms-felogin": "Can be used to authenticate to an internal member area (^13.4)",
-        "typo3/cms-scheduler": "Can be used to perform garbage collection of deregistered members (^13.4)"
+        "typo3/cms-felogin": "Can be used to authenticate to an internal member area (~13.4.13)",
+        "typo3/cms-scheduler": "Can be used to perform garbage collection of deregistered members (~13.4.13)"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d42d8bb3028c0e88954109313317ac80",
+    "content-hash": "0f1f132becaaec9a419cdec25b9d4a55",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -4991,23 +4991,23 @@
         },
         {
             "name": "typo3/cms-backend",
-            "version": "v13.4.11",
+            "version": "v13.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/backend.git",
-                "reference": "648985fe9440c2042f52e19066c0bce9a1e9d7a3"
+                "reference": "3ca361186d243c8769e5cab89bf4cf65b97e32af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/backend/zipball/648985fe9440c2042f52e19066c0bce9a1e9d7a3",
-                "reference": "648985fe9440c2042f52e19066c0bce9a1e9d7a3",
+                "url": "https://api.github.com/repos/TYPO3-CMS/backend/zipball/3ca361186d243c8769e5cab89bf4cf65b97e32af",
+                "reference": "3ca361186d243c8769e5cab89bf4cf65b97e32af",
                 "shasum": ""
             },
             "require": {
                 "ext-intl": "*",
                 "ext-libxml": "*",
                 "psr/event-dispatcher": "^1.0",
-                "typo3/cms-core": "13.4.11"
+                "typo3/cms-core": "13.4.13"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -5069,7 +5069,7 @@
                 "issues": "https://forge.typo3.org",
                 "source": "https://github.com/typo3/typo3"
             },
-            "time": "2025-05-14T11:52:43+00:00"
+            "time": "2025-05-27T13:51:19+00:00"
         },
         {
             "name": "typo3/cms-cli",
@@ -5181,16 +5181,16 @@
         },
         {
             "name": "typo3/cms-core",
-            "version": "v13.4.11",
+            "version": "v13.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/core.git",
-                "reference": "7e7e240176ab6c2adcc695221d1d505b02ae135c"
+                "reference": "5188e318cfbafe7caa18ac15d5094268de72425b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/core/zipball/7e7e240176ab6c2adcc695221d1d505b02ae135c",
-                "reference": "7e7e240176ab6c2adcc695221d1d505b02ae135c",
+                "url": "https://api.github.com/repos/TYPO3-CMS/core/zipball/5188e318cfbafe7caa18ac15d5094268de72425b",
+                "reference": "5188e318cfbafe7caa18ac15d5094268de72425b",
                 "shasum": ""
             },
             "require": {
@@ -5250,7 +5250,7 @@
                 "typo3/cms-cli": "^3.1.1",
                 "typo3/cms-composer-installers": "^5.0.1",
                 "typo3/html-sanitizer": "^2.2.0",
-                "typo3fluid/fluid": "^4.1.2"
+                "typo3fluid/fluid": "^4.2.0"
             },
             "conflict": {
                 "hoa/core": "*",
@@ -5322,20 +5322,20 @@
                 "issues": "https://forge.typo3.org",
                 "source": "https://github.com/typo3/typo3"
             },
-            "time": "2025-05-14T11:52:43+00:00"
+            "time": "2025-05-27T13:51:19+00:00"
         },
         {
             "name": "typo3/cms-extbase",
-            "version": "v13.4.11",
+            "version": "v13.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/extbase.git",
-                "reference": "c9d2858acd3e62b066a905bdbc20cf8e90f54c11"
+                "reference": "0a71c37cabce5bd732623ed33d578560e2feda81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/extbase/zipball/c9d2858acd3e62b066a905bdbc20cf8e90f54c11",
-                "reference": "c9d2858acd3e62b066a905bdbc20cf8e90f54c11",
+                "url": "https://api.github.com/repos/TYPO3-CMS/extbase/zipball/0a71c37cabce5bd732623ed33d578560e2feda81",
+                "reference": "0a71c37cabce5bd732623ed33d578560e2feda81",
                 "shasum": ""
             },
             "require": {
@@ -5345,7 +5345,7 @@
                 "symfony/dependency-injection": "^7.2",
                 "symfony/property-access": "^7.2",
                 "symfony/property-info": "^7.2",
-                "typo3/cms-core": "13.4.11"
+                "typo3/cms-core": "13.4.13"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -5392,25 +5392,25 @@
                 "issues": "https://forge.typo3.org",
                 "source": "https://github.com/typo3/typo3"
             },
-            "time": "2025-05-14T11:52:43+00:00"
+            "time": "2025-05-27T13:51:19+00:00"
         },
         {
             "name": "typo3/cms-frontend",
-            "version": "v13.4.11",
+            "version": "v13.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/frontend.git",
-                "reference": "4f995c0a2a41282e94ea95e6300b681624ce9751"
+                "reference": "107572b7a218fcb48aad77d0f7dc64e0e21dba28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/frontend/zipball/4f995c0a2a41282e94ea95e6300b681624ce9751",
-                "reference": "4f995c0a2a41282e94ea95e6300b681624ce9751",
+                "url": "https://api.github.com/repos/TYPO3-CMS/frontend/zipball/107572b7a218fcb48aad77d0f7dc64e0e21dba28",
+                "reference": "107572b7a218fcb48aad77d0f7dc64e0e21dba28",
                 "shasum": ""
             },
             "require": {
                 "ext-libxml": "*",
-                "typo3/cms-core": "13.4.11"
+                "typo3/cms-core": "13.4.13"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -5462,7 +5462,7 @@
                 "issues": "https://forge.typo3.org",
                 "source": "https://github.com/typo3/typo3"
             },
-            "time": "2025-05-14T11:52:43+00:00"
+            "time": "2025-05-27T13:51:19+00:00"
         },
         {
             "name": "typo3/html-sanitizer",
@@ -5517,16 +5517,16 @@
         },
         {
             "name": "typo3fluid/fluid",
-            "version": "4.1.2",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3/Fluid.git",
-                "reference": "0b9f07e63858c526333a1f5f518c6ef3b6027645"
+                "reference": "f70cd55da0f5aefc411da3f201503e16df155a03"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3/Fluid/zipball/0b9f07e63858c526333a1f5f518c6ef3b6027645",
-                "reference": "0b9f07e63858c526333a1f5f518c6ef3b6027645",
+                "url": "https://api.github.com/repos/TYPO3/Fluid/zipball/f70cd55da0f5aefc411da3f201503e16df155a03",
+                "reference": "f70cd55da0f5aefc411da3f201503e16df155a03",
                 "shasum": ""
             },
             "require": {
@@ -5572,7 +5572,7 @@
                 "issues": "https://github.com/TYPO3/Fluid/issues",
                 "source": "https://github.com/TYPO3/Fluid"
             },
-            "time": "2025-04-22T08:28:25+00:00"
+            "time": "2025-05-19T11:24:59+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -5636,20 +5636,20 @@
     "packages-dev": [
         {
             "name": "typo3/cms-felogin",
-            "version": "v13.4.11",
+            "version": "v13.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/felogin.git",
-                "reference": "83e1e3d41e82b66f25a811edd5da79b492e1dda4"
+                "reference": "a671477533b2a20f4ec58cb360f17f82d7b2a459"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/felogin/zipball/83e1e3d41e82b66f25a811edd5da79b492e1dda4",
-                "reference": "83e1e3d41e82b66f25a811edd5da79b492e1dda4",
+                "url": "https://api.github.com/repos/TYPO3-CMS/felogin/zipball/a671477533b2a20f4ec58cb360f17f82d7b2a459",
+                "reference": "a671477533b2a20f4ec58cb360f17f82d7b2a459",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "13.4.11"
+                "typo3/cms-core": "13.4.13"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -5690,24 +5690,24 @@
                 "issues": "https://forge.typo3.org",
                 "source": "https://github.com/typo3/typo3"
             },
-            "time": "2025-05-14T11:52:43+00:00"
+            "time": "2025-05-27T13:51:19+00:00"
         },
         {
             "name": "typo3/cms-scheduler",
-            "version": "v13.4.11",
+            "version": "v13.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/scheduler.git",
-                "reference": "35721edeee816b21c08ad518893ac4437f52514e"
+                "reference": "827f7d46a1306d6162bf4a7562682ef6e94ae7be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/scheduler/zipball/35721edeee816b21c08ad518893ac4437f52514e",
-                "reference": "35721edeee816b21c08ad518893ac4437f52514e",
+                "url": "https://api.github.com/repos/TYPO3-CMS/scheduler/zipball/827f7d46a1306d6162bf4a7562682ef6e94ae7be",
+                "reference": "827f7d46a1306d6162bf4a7562682ef6e94ae7be",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "13.4.11"
+                "typo3/cms-core": "13.4.13"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -5745,7 +5745,7 @@
                 "issues": "https://forge.typo3.org",
                 "source": "https://github.com/typo3/typo3"
             },
-            "time": "2025-05-14T11:52:43+00:00"
+            "time": "2025-05-27T13:51:19+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
This PR adds a new `DateIntervalValidator` and configures the `dateOfBirth` property with an interval of `P18Y` (18 years, configurable via site settings). If the member is younger than 18 years, an error is shown:

<img width="617" alt="image" src="https://github.com/user-attachments/assets/bfaf5020-53dc-42d6-a29d-1ca37a8ad625" />

Resolves: #11