### PR TITLE
[BUGFIX] Move EXT:felogin to production requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,15 +15,14 @@
         "typo3/cms-backend": "~13.4.13",
         "typo3/cms-core": "~13.4.13",
         "typo3/cms-extbase": "~13.4.13",
+        "typo3/cms-felogin": "~13.4.13",
         "typo3/cms-frontend": "~13.4.13",
         "typo3fluid/fluid": "^4.1"
     },
     "require-dev": {
-        "typo3/cms-felogin": "~13.4.13",
         "typo3/cms-scheduler": "~13.4.13"
     },
     "suggest": {
-        "typo3/cms-felogin": "Can be used to authenticate to an internal member area (~13.4.13)",
         "typo3/cms-scheduler": "Can be used to perform garbage collection of deregistered members (~13.4.13)"
     },
     "autoload": {


### PR DESCRIPTION
We use (and actually require) parts of EXT:felogin in production code (for example, the `felogin.pid` setting). EXT:felogin should therefore be a hard requirement of the extension.